### PR TITLE
Add API call tracking for MCP tools

### DIFF
--- a/api/src/db/models.py
+++ b/api/src/db/models.py
@@ -94,13 +94,12 @@ class DBFeedback(SQLModel, table=True):
     updated_at: datetime = Field(default_factory=datetime.utcnow, sa_column_kwargs={"onupdate": datetime.utcnow})
 
 
-# class DBQueryHistory(SQLModel, table=True):
-#     __tablename__ = "queries"
-#     id: UUID = Field(default_factory=uuid4, primary_key=True)
-#     user_id: UUID = Field(foreign_key="users.id", index=True)
-#     api_key_id: UUID | None = Field(default=None, foreign_key="api_keys.id", index=True)  # Nullable API key reference
-#     query_text: str
-#     packages_detected: list = Field(default_factory=list, sa_column=Column(JSON))  # JSON array of detected packages
-#     credits_consumed: int = Field(default=1)
-#     created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
-#     updated_at: datetime = Field(default_factory=datetime.utcnow, sa_column_kwargs={"onupdate": datetime.utcnow})
+class DBApiCall(SQLModel, table=True):
+    __tablename__ = "api_calls"
+    id: UUID = Field(default_factory=uuid4, primary_key=True)
+    user_id: UUID = Field(foreign_key="users.id", index=True)
+    endpoint: str = Field(index=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    updated_at: datetime = Field(
+        default_factory=datetime.utcnow, sa_column_kwargs={"onupdate": datetime.utcnow}
+    )

--- a/api/src/mcp_server.py
+++ b/api/src/mcp_server.py
@@ -14,6 +14,7 @@ from mcp.server.auth.settings import AuthSettings
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 from src.db.operations import managed_session
+from src.routes.v1.api_calls.service import ApiCallService
 from src.routes.v1.apikeys.service import APIKeyService
 from src.routes.v1.commit_cache.service import CommitCacheService
 from src.routes.v1.feedback.schema import FeedbackType
@@ -132,6 +133,15 @@ async def _resolve_source_code(
     return None
 
 
+async def track_api_call(endpoint: str) -> None:
+    access_token = get_access_token()
+    if not access_token:
+        return
+    user_id = uuid.UUID(access_token.client_id)
+    async with managed_session() as session:
+        await ApiCallService(db_session=session).create(user_id=user_id, endpoint=endpoint)
+
+
 async def resolve_package(ecosystem: str, package_name: str, version: str | None = None) -> tuple[bytes, str, str]:
     """Resolve a package to a tarball and version/commit identifier.
 
@@ -209,6 +219,7 @@ async def glob(
     except (HTTPException, ValueError) as e:
         return f"Error: {e}"
 
+    await track_api_call("glob")
     files = get_file_tree(tarball_bytes)
 
     if path:
@@ -308,6 +319,8 @@ async def grep(
         tarball_bytes, _, source_label = await resolve_package(ecosystem, package_name, version)
     except (HTTPException, ValueError) as e:
         return f"Error: {e}"
+
+    await track_api_call("grep")
 
     try:
         regex, using_re2 = _compile_re2(pattern, case_insensitive, multiline)
@@ -428,6 +441,8 @@ async def read(
     except (HTTPException, ValueError) as e:
         return f"Error: {e}"
 
+    await track_api_call("read")
+
     try:
         content = get_file_content(tarball_bytes, file_path)
     except FileNotFoundError as e:
@@ -493,6 +508,8 @@ async def submit_feedback(feedback_type: FeedbackType, text: str) -> str:
     access_token = get_access_token()
     if not access_token:
         return "Error: Authentication required"
+
+    await track_api_call("submit_feedback")
 
     user_id = uuid.UUID(access_token.client_id)
 

--- a/api/src/routes/v1/api_calls/repository.py
+++ b/api/src/routes/v1/api_calls/repository.py
@@ -1,0 +1,15 @@
+from sqlmodel.ext.asyncio.session import AsyncSession
+from src.db.models import DBApiCall
+from src.routes.v1.api_calls.schema import ApiCallInput
+
+
+class ApiCallRepository:
+    def __init__(self, db_session: AsyncSession) -> None:
+        self.db_session = db_session
+
+    async def create(self, data: ApiCallInput) -> DBApiCall:
+        api_call = DBApiCall(**data.model_dump())
+        self.db_session.add(api_call)
+        await self.db_session.commit()
+        await self.db_session.refresh(api_call)
+        return api_call

--- a/api/src/routes/v1/api_calls/schema.py
+++ b/api/src/routes/v1/api_calls/schema.py
@@ -1,0 +1,8 @@
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class ApiCallInput(BaseModel):
+    user_id: UUID
+    endpoint: str

--- a/api/src/routes/v1/api_calls/service.py
+++ b/api/src/routes/v1/api_calls/service.py
@@ -1,0 +1,15 @@
+import uuid
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+from src.db.models import DBApiCall
+from src.routes.v1.api_calls.repository import ApiCallRepository
+from src.routes.v1.api_calls.schema import ApiCallInput
+
+
+class ApiCallService:
+    def __init__(self, db_session: AsyncSession) -> None:
+        self.repository = ApiCallRepository(db_session=db_session)
+
+    async def create(self, user_id: uuid.UUID, endpoint: str) -> DBApiCall:
+        api_call_input = ApiCallInput(user_id=user_id, endpoint=endpoint)
+        return await self.repository.create(api_call_input)


### PR DESCRIPTION
## Summary
- Add `DBApiCall` model with `user_id`, `endpoint`, and timestamps to track tool usage
- Add `api_calls` resource module (repository, schema, service) following existing patterns
- Track each authenticated MCP tool invocation: `glob`, `grep`, `read`, `submit_feedback`
- Replace commented-out `DBQueryHistory` model with the new implementation

## Test plan
- [ ] Run database migration to create `api_calls` table
- [ ] Call each MCP tool and verify rows are inserted into `api_calls`
- [ ] Verify unauthenticated calls are not tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)